### PR TITLE
Add EFCore.BulkExtensions and changed to SQLite for Tests

### DIFF
--- a/WireMock.Test/WireMock.Test.csproj
+++ b/WireMock.Test/WireMock.Test.csproj
@@ -14,6 +14,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SQLite" Version="8.0.7" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
         <PackageReference Include="MSTest.TestAdapter" Version="3.0.4"/>
         <PackageReference Include="MSTest.TestFramework" Version="3.0.4"/>

--- a/WireMock/Data/WireMockRepository.cs
+++ b/WireMock/Data/WireMockRepository.cs
@@ -1,3 +1,4 @@
+using EFCore.BulkExtensions;
 using Microsoft.EntityFrameworkCore;
 using WireMock.Server;
 
@@ -76,16 +77,20 @@ public class WireMockRepository(
                 => m.Id == serviceId);
 
         var existingMappings = service.Mappings.ToList();
-        foreach (var newMapping in newMappings)
-        {
-            if (existingMappings.Any(existingMapping => existingMapping.Guid.Equals(newMapping.Item1)))
-                continue; // skip if the mapping already exists
+        var mappingsToAdd =
+            (from newMapping in newMappings
+                where !existingMappings.Any(existingMapping
+                    => existingMapping.Guid.Equals(newMapping.Item1))
+                select new WireMockServerMapping
+                {
+                    Guid = newMapping.Item1, 
+                    Raw = newMapping.Item2, 
+                    WireMockServerModelId = serviceId
+                })
+            .ToList();
 
-            service.Mappings.Add(new WireMockServerMapping
-            {
-                Guid = newMapping.Item1, Raw = newMapping.Item2
-            });
-        }
+        if (mappingsToAdd.Count != 0)
+            await context.BulkInsertAsync(mappingsToAdd);
 
         await context.SaveChangesAsync();
     }
@@ -140,7 +145,10 @@ public class WireMockRepository(
         var mappingsToRemove = context.WireMockServerMapping
             .ToList()
             .Where(m => guids.Any(guid => guid.Equals(m.Guid)));
-        context.WireMockServerMapping.RemoveRange(mappingsToRemove);
+
+        await context.BulkDeleteAsync(mappingsToRemove);
+        // context.WireMockServerMapping.RemoveRange(mappingsToRemove);
+
         await context.SaveChangesAsync();
     }
 }

--- a/WireMock/Properties/launchSettings.json
+++ b/WireMock/Properties/launchSettings.json
@@ -12,7 +12,8 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
+      "hotReloadEnabled": true,
       "applicationUrl": "http://localhost:5024",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -21,7 +22,8 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
+      "launchBrowser": false,
+      "hotReloadEnabled": true,
       "applicationUrl": "https://localhost:7242;http://localhost:5024",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/WireMock/WireMock.csproj
+++ b/WireMock/WireMock.csproj
@@ -8,13 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EFCore.BulkExtensions.Sqlite" Version="8.1.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SQLite" Version="8.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SQLite" Version="8.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
* Add EFCore.BulkExtensions and enable hot reload

Include EFCore.BulkExtensions for bulk operations and refactor related methods for better performance in WireMockRepository. Update launch settings to disable browser launch and enable hot reload for improved development experience.

* Use SQLite for tests

Modified the tests to utilize an in-memory SQLite database instead of EntityFrameworkCore.InMemory for more realistic testing. Also upgraded Microsoft.EntityFrameworkCore.SQLite package to version 8.0.7 in main and test projects.