### PR TITLE
fixing #10 - Exception on calling mapping for a not running service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/05e6f15388244258b9435b6c64f86691)](https://app.codacy.com/gh/vanUbor/Wiremock/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+
 docker build -t wiremock-debug .
 docker run -p 8080:8080 -p 8083:8083 -p 5001:5001 wiremock-debug

--- a/WireMock.Test/Pages/MappingsTest.cs
+++ b/WireMock.Test/Pages/MappingsTest.cs
@@ -93,7 +93,7 @@ public class MappingsTest
     public async Task OnGet_WithNoServiceRunningTest()
     {
         // Arrange
-        var sortOrder = "date";
+        const string sortOrder = "date";
         var configMock = new Mock<IConfiguration>();
         var configSectionMock = new Mock<IConfigurationSection>();
         configSectionMock.SetupGet(m => m.Value).Returns("42");
@@ -102,8 +102,8 @@ public class MappingsTest
 
         var mappings = new Mappings(clientFactory, orchestrator, repository, configMock.Object);
 
-        var serviceId = 69;
-        var pageIndex = 1;
+        const int serviceId = 69;
+        const int pageIndex = 1;
 
         // Act
         var actionResult = await mappings.OnGet(serviceId, sortOrder, pageIndex);

--- a/WireMock.Test/Pages/MappingsTest.cs
+++ b/WireMock.Test/Pages/MappingsTest.cs
@@ -16,10 +16,12 @@ public class MappingsTest
     private IHttpClientFactory clientFactory;
     private IWireMockRepository repository;
     private Mock<HttpMessageHandler> handlerMock;
+    private ServiceOrchestrator orchestrator;
 
     [TestInitialize]
     public void Setup()
     {
+        
         handlerMock = new Mock<HttpMessageHandler>();
         var response = new HttpResponseMessage
         {
@@ -52,6 +54,8 @@ public class MappingsTest
                 Name = "UnitTestServiceModel",
                 Port = 8081
             });
+        var list = new Mock<WireMockServiceList>();
+        orchestrator = new Mock<ServiceOrchestrator>(list.Object, repository).Object;
     }
 
 
@@ -71,7 +75,7 @@ public class MappingsTest
         configMock.Setup(m => m.GetSection("PageSize"))
             .Returns(configSectionMock.Object);
         
-        var mappings = new Mappings(clientFactory, repository, configMock.Object);
+        var mappings = new Mappings(clientFactory, orchestrator, repository, configMock.Object);
 
         var serviceId = 42;
         var pageIndex = 1;
@@ -103,7 +107,7 @@ public class MappingsTest
         repositoryMock.Setup(x => x.UpdateMappingAsync(It.IsAny<Guid>(), It.IsAny<string>()))
             .Returns(Task.CompletedTask);
 
-        var mappings = new Mappings(clientFactory, repositoryMock.Object, configMock.Object);
+        var mappings = new Mappings(clientFactory, orchestrator, repositoryMock.Object, configMock.Object);
 
         string serviceId = "42";
         string guid = Guid.NewGuid().ToString();
@@ -137,7 +141,7 @@ public class MappingsTest
                 Port = 8081
             });
 
-        var mappings = new Mappings(clientFactory, repositoryMock.Object, configMock.Object);
+        var mappings = new Mappings(clientFactory, orchestrator, repositoryMock.Object, configMock.Object);
 
         var serviceId = "42";
         var guid = new Guid().ToString();
@@ -167,7 +171,7 @@ public class MappingsTest
                 Port = 8081
             });
 
-        var mappings = new Mappings(clientFactory, repositoryMock.Object, configMock.Object);
+        var mappings = new Mappings(clientFactory, orchestrator, repositoryMock.Object, configMock.Object);
         var serviceId = "42";
 
         // Act

--- a/WireMock.Test/ServerOrchestratorTest.cs
+++ b/WireMock.Test/ServerOrchestratorTest.cs
@@ -1,4 +1,5 @@
-﻿using NSubstitute;
+﻿using Moq;
+using NSubstitute;
 using WireMock.Data;
 using WireMock.Server;
 
@@ -151,5 +152,27 @@ public class ServerOrchestratorTest
         // Assert
         var service = _serviceList!.Single(s => s.Id == 1.ToString());
         Assert.IsTrue(service.IsRunning);
+    }
+
+    [TestMethod]
+    [DataRow(42, true)]
+    [DataRow(69, false)]
+    public void IsRunning_Successful(int serviceId, bool isRunning)
+    {
+        var model = new WireMockServiceModel()
+        {
+            Id = 42,
+            Name = "UnitTestModel"
+        };
+        var serviceMock = new Mock<WireMockService>(model);
+        serviceMock.SetupGet(s => s.IsRunning).Returns(isRunning);
+        _serviceList!.Add(serviceMock.Object);
+        var orchestrator = new ServiceOrchestrator(_serviceList!, _repo!);
+        
+        // Act
+        var runns = orchestrator.IsRunning(serviceId);
+        
+        // Assert
+        Assert.AreEqual(isRunning, runns);
     }
 }

--- a/WireMock.Test/ServerOrchestratorTest.cs
+++ b/WireMock.Test/ServerOrchestratorTest.cs
@@ -159,7 +159,7 @@ public class ServerOrchestratorTest
     [DataRow(69, false)]
     public void IsRunning_Successful(int serviceId, bool isRunning)
     {
-        var model = new WireMockServiceModel()
+        var model = new WireMockServiceModel
         {
             Id = 42,
             Name = "UnitTestModel"

--- a/WireMock.Test/WireMockRepositoryTest.cs
+++ b/WireMock.Test/WireMockRepositoryTest.cs
@@ -1,4 +1,3 @@
-using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using WireMock.Data;

--- a/WireMock.sln
+++ b/WireMock.sln
@@ -8,6 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{CBB5
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\dotnet.yml = .github\workflows\dotnet.yml
 		codecov.yml = codecov.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/WireMock/Data/ServiceOrchestrator.cs
+++ b/WireMock/Data/ServiceOrchestrator.cs
@@ -132,4 +132,14 @@ public class ServiceOrchestrator
     /// <param name="model">The WireMockServiceModel used to create the service.</param>
     private WireMockService CreateService(WireMockServiceModel model)
         => new WireMockService(model);
+
+    /// <summary>
+    /// Checks if a service with the provided service Id is currently running
+    /// </summary>
+    /// <param name="serviceId">the service id of the service which gets checked</param>
+    public bool IsRunning(int serviceId)
+    {
+        var service = _services?.FirstOrDefault(s => s.Id.Equals(serviceId.ToString()));
+        return service?.IsRunning ?? false;
+    }
 }

--- a/WireMock/Data/ServiceOrchestrator.cs
+++ b/WireMock/Data/ServiceOrchestrator.cs
@@ -137,7 +137,7 @@ public class ServiceOrchestrator
     /// Checks if a service with the provided service Id is currently running
     /// </summary>
     /// <param name="serviceId">the service id of the service which gets checked</param>
-    public bool IsRunning(int serviceId)
+    public virtual bool IsRunning(int serviceId)
     {
         var service = _services?.FirstOrDefault(s => s.Id.Equals(serviceId.ToString()));
         return service?.IsRunning ?? false;

--- a/WireMock/Pages/WireMockService/Mappings.cshtml.cs
+++ b/WireMock/Pages/WireMockService/Mappings.cshtml.cs
@@ -1,17 +1,16 @@
-using System.Runtime.InteropServices.JavaScript;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using WireMock.Data;
 using WireMock.Server;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace WireMock.Pages.WireMockService;
 
-public class Mappings(IHttpClientFactory clientFactory, IWireMockRepository Repository, IConfiguration Config) 
+public class Mappings(IHttpClientFactory clientFactory,
+    ServiceOrchestrator serviceOrchestrator,
+    IWireMockRepository Repository, 
+    IConfiguration Config) 
     : PageModel
 {
     public int ServiceId { get; set; }
@@ -26,6 +25,8 @@ public class Mappings(IHttpClientFactory clientFactory, IWireMockRepository Repo
     private HttpClient _client = clientFactory.CreateClient();
     public async Task<IActionResult> OnGet(int id, string sortOrder, int? pageIndex)
     {
+        if (!serviceOrchestrator.IsRunning(id))
+            return RedirectToPage("../Error");
         
         ServiceId = id;
         GuidSort = String.IsNullOrEmpty(sortOrder) ? "guid_desc" : "";

--- a/WireMock/Pages/WireMockService/Mappings.cshtml.cs
+++ b/WireMock/Pages/WireMockService/Mappings.cshtml.cs
@@ -26,7 +26,9 @@ public class Mappings(IHttpClientFactory clientFactory,
     public async Task<IActionResult> OnGet(int id, string sortOrder, int? pageIndex)
     {
         if (!serviceOrchestrator.IsRunning(id))
+        {
             return RedirectToPage("../Error");
+        }
         
         ServiceId = id;
         GuidSort = String.IsNullOrEmpty(sortOrder) ? "guid_desc" : "";

--- a/WireMock/Pages/WireMockService/PaginatedList.cs
+++ b/WireMock/Pages/WireMockService/PaginatedList.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-
-namespace WireMock.Pages.WireMockService
+﻿namespace WireMock.Pages.WireMockService
 {
     public class PaginatedList<T> : List<T>
     {

--- a/WireMock/Server/WireMockService.cs
+++ b/WireMock/Server/WireMockService.cs
@@ -12,7 +12,7 @@ public class WireMockService(WireMockServiceModel model)
 {
     public string Id => model.Id.ToString();
     public string Name => model.Name;
-    public bool IsRunning => _server?.IsStarted ?? false;
+    public virtual bool IsRunning => _server?.IsStarted ?? false;
 
     public EventHandler<ChangedMappingsArgs>? MappingsAdded;
     public EventHandler<ChangedMappingsArgs>? MappingsRemoved;


### PR DESCRIPTION
Integrated a ServiceOrchestrator to manage service run checks in Mappings. This ensures that the service is running before certain actions and updates various tests to accommodate the orchestrator. Removed some redundant using directives for cleaner code.